### PR TITLE
fix bug

### DIFF
--- a/cardlib/src/main/java/com/lin/cardlib/utils/ReItemTouchHelper.java
+++ b/cardlib/src/main/java/com/lin/cardlib/utils/ReItemTouchHelper.java
@@ -184,6 +184,9 @@ public class ReItemTouchHelper extends RecyclerView.ItemDecoration
             }
             final int action = MotionEventCompat.getActionMasked(event);
             if (action == MotionEvent.ACTION_DOWN) {
+                if (recyclerView.getAdapter() != null && recyclerView.getAdapter().getItemCount() > 0) {
+                    recyclerView.getParent().requestDisallowInterceptTouchEvent(true);
+                }
                 mActivePointerId = event.getPointerId(0);
                 mInitialTouchX = event.getX();
                 mInitialTouchY = event.getY();
@@ -202,6 +205,7 @@ public class ReItemTouchHelper extends RecyclerView.ItemDecoration
                     }
                 }
             } else if (action == MotionEvent.ACTION_CANCEL || action == MotionEvent.ACTION_UP) {
+                recyclerView.getParent().requestDisallowInterceptTouchEvent(false);
                 mActivePointerId = ACTIVE_POINTER_ID_NONE;
                 select(null, ACTION_STATE_IDLE);
             } else if (mActivePointerId != ACTIVE_POINTER_ID_NONE) {


### PR DESCRIPTION
解决bug: 当该控件所在的fragment属于viewpager中的一个fragment的时候，快速滑动该控件，事件被viewpager拦截，导致该控件卡片没滑动，而滑动到viewpager相邻的fragment了。

所以当该控件(RecyclerView)有item的时候，如果点击作用在该控件上，那么请求父控件不对后续事件进行拦截。应该也能fix 这个[#12](https://github.com/JerryChan123/ReSwipeCard/issues/12#)